### PR TITLE
Renombra etiquetas FL a LD

### DIFF
--- a/intelligent_systems/FL/templates/migration_FL.html
+++ b/intelligent_systems/FL/templates/migration_FL.html
@@ -1,15 +1,15 @@
 {% extends 'layout/sidebar.html' %}
 
 {% block title %}
- FL (Logica Difusa)
+ LD (Lógica Difusa)
 {% endblock %}
 
 {% block content %}
 <div class="container mx-auto px-4 py-8">
   <h1 class="text-3xl font-bold text-blue-700 mb-2">
-    Subir Archivo de Excel para Algoritmo FL
+    Subir Archivo de Excel para Algoritmo LD
   </h1>
-  <h2 class="text-xl font-medium text-blue-500 mb-8">(Lógica Difusa)</h2>
+  <h2 class="text-xl font-medium text-blue-500 mb-8">(Lógica Difusa (LD))</h2>
 
   <form method="POST" action="#" enctype="multipart/form-data" class="bg-white p-8 rounded-xl shadow-lg border border-blue-100">
     {% csrf_token %}

--- a/intelligent_systems/analisis_eficiencia/templates/analisis_comparativo.html
+++ b/intelligent_systems/analisis_eficiencia/templates/analisis_comparativo.html
@@ -24,7 +24,7 @@
     <h2 class="text-2xl font-semibold text-blue-600 mb-4">Respuestas de encuesta (Conocimiento) - Profesores</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Difusa (FL)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Difusa (LD)</h3>
             <canvas id="profesores-logica-difusa" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -32,7 +32,7 @@
             <canvas id="profesores-ast" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y FL (Profesores)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y LD (Profesores)</h3>
             <canvas id="comparacion-encuesta-profesores" class="w-full h-64"></canvas>
         </div>
     </div>
@@ -43,7 +43,7 @@
     <h2 class="text-2xl font-semibold text-blue-600 mb-4">Respuestas de encuesta (Satisfacción) - Estudiantes</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Difusa (FL)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Difusa (LD)</h3>
             <canvas id="estudiantes-logica-difusa" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -51,7 +51,7 @@
             <canvas id="estudiantes-ast" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y FL (Estudiantes)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y LD (Estudiantes)</h3>
             <canvas id="comparacion-encuesta-estudiantes" class="w-full h-64"></canvas>
         </div>
     </div>
@@ -75,7 +75,7 @@
             <div id="matrizAst" class="w-full h-64"></div>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Matriz de Confusión (FL)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Matriz de Confusión (LD)</h3>
             <div id="matrizFl" class="w-full h-64"></div>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -235,7 +235,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                         backgroundColor: 'rgba(75, 192, 192, 0.6)',
                                     },
                                     {
-                                        label: 'Lógica Difusa',
+                                        label: 'Lógica Difusa (LD)',
                                         data: lfData,
                                         backgroundColor: 'rgba(255, 99, 132, 0.6)',
                                     },
@@ -352,7 +352,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                         backgroundColor: 'rgba(75, 192, 192, 0.6)',
                                     },
                                     {
-                                        label: 'Lógica Difusa',
+                                        label: 'Lógica Difusa (LD)',
                                         data: lfDataEst,
                                         backgroundColor: 'rgba(255, 99, 132, 0.6)',
                                     },
@@ -443,7 +443,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
                                 // Configuración del layout
                                 const layoutFL = {
-                                    title: `${'FL'}<br>Recall: ${dataFL.recall?.toFixed(2)}`,
+                                    title: `${'LD'}<br>Recall: ${dataFL.recall?.toFixed(2)}`,
                                     xaxis: {
                                         title: 'Valores Predicción',
                                         tickvals: [0, 1],
@@ -494,7 +494,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 chartRecall = new Chart(recallComparativo, {
                                     type: 'bar',
                                     data: {
-                                        labels: ['AST', 'FL'],
+                                        labels: ['AST', 'LD'],
                                         datasets: [{
                                             label: 'Recall',
                                             data: [respuestaMatrizConfucion.data.AST.recall, respuestaMatrizConfucion.data.FL.recall],

--- a/intelligent_systems/analisis_eficiencia/templates/analisis_docente.html
+++ b/intelligent_systems/analisis_eficiencia/templates/analisis_docente.html
@@ -28,9 +28,9 @@
                     <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) AST</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) AST</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">% AST</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) FL</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) FL</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">% FL</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) LD</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) LD</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">% LD</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">% Compatibilidad</th>
                 </tr>
             </thead>

--- a/intelligent_systems/analisis_eficiencia/templates/docentes_asignados.html
+++ b/intelligent_systems/analisis_eficiencia/templates/docentes_asignados.html
@@ -14,9 +14,9 @@
                     <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) AST</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) AST</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">% AST</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) FL</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) FL</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">% FL</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) LD</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) LD</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">% LD</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">% Compatibilidad</th>
                     <!-- Neutrosofía Profesor -->
                     <th class="px-6 py-3 text-center text-sm font-semibold">Verdad Profesor (T)</th>

--- a/intelligent_systems/migration_excel/templates/migration_excel.html
+++ b/intelligent_systems/migration_excel/templates/migration_excel.html
@@ -6,10 +6,10 @@
   <div class="grid grid-cols-1 md:grid-cols-3 mb-8">
     <div class="col-span-2">
       <h1 class="text-3xl font-bold text-blue-700 mb-2">
-        Subir Archivo de Excel para los algoritmos de AST y FL
+        Subir Archivo de Excel para los algoritmos de AST y LD
       </h1>
       <h2 class="text-xl font-medium text-blue-500">
-        (Arbol de Sintaxis Abstracta y Lógica Difusa)
+        (Arbol de Sintaxis Abstracta y Lógica Difusa (LD))
       </h2>
     </div>
     <div class="flex justify-end items-start">


### PR DESCRIPTION
## Summary
- renombre etiquetas visibles de Lógica Difusa a LD en las vistas de análisis comparativo
- actualicé encabezados y labels de FL a LD en pantallas de docentes y migraciones

## Testing
- `python intelligent_systems/manage.py test` *(falla: django.core.exceptions.ImproperlyConfigured: Set the DB_NAME environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689ac03cfa00832892562c9c67a4a9ac