### PR TITLE
Actualizar etiquetas a Lógica Neutrosófica

### DIFF
--- a/intelligent_systems/FL/templates/migration_FL.html
+++ b/intelligent_systems/FL/templates/migration_FL.html
@@ -1,15 +1,15 @@
 {% extends 'layout/sidebar.html' %}
 
 {% block title %}
- LD (Lógica Difusa)
+ LN (Lógica Neutrosófica)
 {% endblock %}
 
 {% block content %}
 <div class="container mx-auto px-4 py-8">
   <h1 class="text-3xl font-bold text-blue-700 mb-2">
-    Subir Archivo de Excel para Algoritmo LD
+    Subir Archivo de Excel para Algoritmo LN
   </h1>
-  <h2 class="text-xl font-medium text-blue-500 mb-8">(Lógica Difusa (LD))</h2>
+  <h2 class="text-xl font-medium text-blue-500 mb-8">(Lógica Neutrosófica (LN))</h2>
 
   <form method="POST" action="#" enctype="multipart/form-data" class="bg-white p-8 rounded-xl shadow-lg border border-blue-100">
     {% csrf_token %}

--- a/intelligent_systems/NEUTRO/templates/analisis_neutro.html
+++ b/intelligent_systems/NEUTRO/templates/analisis_neutro.html
@@ -9,41 +9,8 @@
     <div class="bg-white rounded-lg shadow-lg p-6">
         <h1 class="text-3xl font-bold text-gray-800 mb-6">Análisis Neutrosófico</h1>
         
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <!-- Análisis de Profesores -->
-            <div class="bg-blue-50 rounded-lg p-6">
-                <div class="relative mb-8">
-                    <input
-                        type="text"
-                        id="buscar-profesor"
-                        class="block w-full p-3 border border-blue-100 rounded-lg shadow-sm focus:ring-blue-200 focus:border-blue-400 placeholder-gray-400"
-                        placeholder="Buscar profesor..."
-                    />
-                    <ul
-                        id="resultados"
-                        class="absolute z-10 mt-2 w-full bg-white border border-blue-100 rounded-lg shadow-lg hidden"
-                    >
-                        <!-- Aquí se llenarán los resultados dinámicamente -->
-                    </ul>
-                </div>
-                <button id="analizar_profesor" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors">
-                    Analizar Profesor
-                </button>
-                <div id="resultados_profesor" class="mt-4"></div>
-            </div>
-
-            <!-- Análisis de Estudiantes -->
-            <div class="bg-green-50 rounded-lg p-6">
-                <h2 class="text-xl font-semibold text-green-800 mb-4">Análisis de Estudiantes</h2>
-                <button id="analizar_estudiantes" class="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors">
-                    Analizar Estudiantes
-                </button>
-                <div id="resultados_estudiantes" class="mt-4"></div>
-            </div>
-        </div>
-
         <!-- Explicación del Análisis Neutrosófico -->
-        <div class="mt-8 bg-gray-50 rounded-lg p-6">
+        <div class="bg-gray-50 rounded-lg p-6">
             <h3 class="text-lg font-semibold text-gray-800 mb-3">¿Qué es el Análisis Neutrosófico?</h3>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-gray-600">
                 <div>
@@ -62,71 +29,4 @@
         </div>
     </div>
 </div>
-
-<script>
-document.addEventListener("DOMContentLoaded", () => {
-    const input = document.getElementById("buscar-profesor");
-    const resultados = document.getElementById("resultados");
-    let debounceTimer; // Variable para almacenar el temporizador del debounce
-    // Función para realizar la búsqueda
-    const buscarProfesores = (query) => {
-        if (query.length === 0) {
-            resultados.classList.add("hidden");
-            return;
-        }
-
-        fetch(`/api/academico/buscar-profesores/?q=${encodeURIComponent(query)}`)
-            .then((response) => response.json())
-            .then((data) => {
-                resultados.innerHTML = ""; // Limpia los resultados anteriores
-                if (data.length > 0) {
-                    resultados.classList.remove("hidden");
-                    data.forEach((profesor) => {
-                        const li = document.createElement("li");
-                        li.textContent = profesor.nombre; // Muestra el nombre completo
-                        li.className = "p-2 hover:bg-indigo-100 cursor-pointer";
-                        li.addEventListener("click", async () => {
-                            try {
-                                input.value = profesor.nombre;
-                                resultados.classList.add("hidden");
-                                const response = await axios.get(`/api/analisis-eficiencia/resultados-encuesta-profesor/?id=${profesor.id}`);
-                                
-                                 
-                            } catch (error) {
-                                console.error(error)
-                                showSweetAlert('Error al cargar los datos', error?.response?.data?.error, 'error');
-                            }
-                        });
-                        resultados.appendChild(li);
-                    });
-                } else {
-                    resultados.classList.add("hidden");
-                }
-            })
-            .catch((error) => {
-                console.error("Error al buscar profesores:", error);
-            });
-    };
-
- 
-
-    // Evento de entrada con debounce
-    input.addEventListener("input", () => {
-        clearTimeout(debounceTimer); // Limpia el temporizador anterior
-        const query = input.value.trim();
-
-        // Inicia un nuevo temporizador
-        debounceTimer = setTimeout( () => {
-            buscarProfesores(query); // Llama a la función después del retraso
-        }, 1000); 
-    });
-
-    // Ocultar la lista si el usuario hace clic fuera del componente
-    document.addEventListener("click", (e) => {
-        if (!input.contains(e.target) && !resultados.contains(e.target)) {
-            resultados.classList.add("hidden");
-        }
-    });
-});
-</script>
-{% endblock %} 
+{% endblock %}

--- a/intelligent_systems/analisis_eficiencia/templates/analisis_comparativo.html
+++ b/intelligent_systems/analisis_eficiencia/templates/analisis_comparativo.html
@@ -24,7 +24,7 @@
     <h2 class="text-2xl font-semibold text-blue-600 mb-4">Respuestas de encuesta (Conocimiento) - Profesores</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Difusa (LD)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Neutrosófica (LN)</h3>
             <canvas id="profesores-logica-difusa" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -32,7 +32,7 @@
             <canvas id="profesores-ast" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y LD (Profesores)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y LN (Profesores)</h3>
             <canvas id="comparacion-encuesta-profesores" class="w-full h-64"></canvas>
         </div>
     </div>
@@ -43,7 +43,7 @@
     <h2 class="text-2xl font-semibold text-blue-600 mb-4">Respuestas de encuesta (Satisfacción) - Estudiantes</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Difusa (LD)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Neutrosófica (LN)</h3>
             <canvas id="estudiantes-logica-difusa" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -51,7 +51,7 @@
             <canvas id="estudiantes-ast" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y LD (Estudiantes)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y LN (Estudiantes)</h3>
             <canvas id="comparacion-encuesta-estudiantes" class="w-full h-64"></canvas>
         </div>
     </div>
@@ -75,7 +75,7 @@
             <div id="matrizAst" class="w-full h-64"></div>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Matriz de Confusión (LD)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Matriz de Confusión (LN)</h3>
             <div id="matrizFl" class="w-full h-64"></div>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -222,7 +222,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 const dataComparacion = [...new Set(response.data.comparation_values)];
                                 const labels = [...new Set(dataComparacion.map(item => item.materia))];
                                 const astData = dataComparacion.filter(item => item.algoritmo === 'Árbol de Sintaxis Abstracta').map(item => item.probabilidad);
-                                const lfData = dataComparacion.filter(item => item.algoritmo === 'Lógica Difusa').map(item => item.probabilidad);
+                                const lfData = dataComparacion.filter(item => item.algoritmo === 'Lógica Neutrosófica').map(item => item.probabilidad);
                                 const ctxComparacion = document.getElementById('comparacion-encuesta-profesores').getContext('2d');
                                 chartComparacion = new Chart(ctxComparacion, {
                                 type: 'bar',
@@ -235,7 +235,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                         backgroundColor: 'rgba(75, 192, 192, 0.6)',
                                     },
                                     {
-                                        label: 'Lógica Difusa (LD)',
+                                        label: 'Lógica Neutrosófica (LN)',
                                         data: lfData,
                                         backgroundColor: 'rgba(255, 99, 132, 0.6)',
                                     },
@@ -339,7 +339,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 const dataComparacionEstudiante = [...new Set(responseEstudiante.data.comparation_values)];
                                 const labelsEst = [...new Set(dataComparacionEstudiante.map(item => item.materia))];
                                 const astDataEst = dataComparacionEstudiante.filter(item => item.algoritmo === 'Árbol de Sintaxis Abstracta').map(item => item.probabilidad);
-                                const lfDataEst = dataComparacionEstudiante.filter(item => item.algoritmo === 'Lógica Difusa').map(item => item.probabilidad);
+                                const lfDataEst = dataComparacionEstudiante.filter(item => item.algoritmo === 'Lógica Neutrosófica').map(item => item.probabilidad);
                                 const ctxComparacionEst = document.getElementById('comparacion-encuesta-estudiantes').getContext('2d');
                                 chartComparacionEst = new Chart(ctxComparacionEst, {
                                 type: 'bar',
@@ -352,7 +352,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                         backgroundColor: 'rgba(75, 192, 192, 0.6)',
                                     },
                                     {
-                                        label: 'Lógica Difusa (LD)',
+                                        label: 'Lógica Neutrosófica (LN)',
                                         data: lfDataEst,
                                         backgroundColor: 'rgba(255, 99, 132, 0.6)',
                                     },
@@ -443,7 +443,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
                                 // Configuración del layout
                                 const layoutFL = {
-                                    title: `${'LD'}<br>Recall: ${dataFL.recall?.toFixed(2)}`,
+                                    title: `${'LN'}<br>Recall: ${dataFL.recall?.toFixed(2)}`,
                                     xaxis: {
                                         title: 'Valores Predicción',
                                         tickvals: [0, 1],
@@ -494,7 +494,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 chartRecall = new Chart(recallComparativo, {
                                     type: 'bar',
                                     data: {
-                                        labels: ['AST', 'LD'],
+                                        labels: ['AST', 'LN'],
                                         datasets: [{
                                             label: 'Recall',
                                             data: [respuestaMatrizConfucion.data.AST.recall, respuestaMatrizConfucion.data.FL.recall],

--- a/intelligent_systems/analisis_eficiencia/templates/analisis_docente.html
+++ b/intelligent_systems/analisis_eficiencia/templates/analisis_docente.html
@@ -28,9 +28,9 @@
                     <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) AST</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) AST</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">% AST</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) LD</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) LD</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">% LD</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) LN</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) LN</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">% LN</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">% Compatibilidad</th>
                 </tr>
             </thead>

--- a/intelligent_systems/analisis_eficiencia/templates/docentes_asignados.html
+++ b/intelligent_systems/analisis_eficiencia/templates/docentes_asignados.html
@@ -14,22 +14,14 @@
                     <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) AST</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) AST</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">% AST</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) LD</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) LD</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">% LD</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Profesor (Conocimiento) LN</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">Encuesta Estudiante (Satisfacción) LN</th>
+                    <th class="px-6 py-3 text-center text-sm font-semibold">% LN</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">% Compatibilidad</th>
                     <!-- Neutrosofía Profesor -->
                     <th class="px-6 py-3 text-center text-sm font-semibold">Verdad Profesor (T)</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">Indeterminación Profesor (I)</th>
                     <th class="px-6 py-3 text-center text-sm font-semibold">Falsedad Profesor (F)</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Score Neutrosófico Profesor</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Deneutrosofía Profesor</th>
-                    <!-- Neutrosofía Estudiante -->
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Verdad Estudiante (T)</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Indeterminación Estudiante (I)</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Falsedad Estudiante (F)</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Score Neutrosófico Estudiante</th>
-                    <th class="px-6 py-3 text-center text-sm font-semibold">Deneutrosofía Estudiante</th>
                 </tr>
             </thead>
             <tbody>
@@ -48,7 +40,7 @@
             tbody.innerHTML = ""; // Limpiar la tabla antes de agregar nuevos datos
 
             datos.forEach(({ materia, profesor, promedio_fl, promedio_ast , puntaje_promedio, puntaje_ast_prof, puntaje_fl_prof, puntaje_ast_est,
-                puntaje_fl_est, T_neutro_prof, I_neutro_prof, F_neutro_prof, score_neutro_prof, deneutrosophy_prof, T_neutro_est, I_neutro_est, F_neutro_est, score_neutro_est, deneutrosophy_est }) => {
+                puntaje_fl_est, T_neutro_prof, I_neutro_prof, F_neutro_prof }) => {
                 const fila = document.createElement("tr");
                 fila.className = "border-b transition duration-300 ease-in-out bg-white hover:bg-blue-50";
 
@@ -66,14 +58,6 @@
                     <td class="px-6 py-4 text-center text-xs">${T_neutro_prof ?? ''}</td>
                     <td class="px-6 py-4 text-center text-xs">${I_neutro_prof ?? ''}</td>
                     <td class="px-6 py-4 text-center text-xs">${F_neutro_prof ?? ''}</td>
-                    <td class="px-6 py-4 text-center text-xs">${score_neutro_prof ?? ''}</td>
-                    <td class="px-6 py-4 text-center text-xs">${deneutrosophy_prof ?? ''}</td>
-                    <!-- Neutrosofía Estudiante -->
-                    <td class="px-6 py-4 text-center text-xs">${T_neutro_est ?? ''}</td>
-                    <td class="px-6 py-4 text-center text-xs">${I_neutro_est ?? ''}</td>
-                    <td class="px-6 py-4 text-center text-xs">${F_neutro_est ?? ''}</td>
-                    <td class="px-6 py-4 text-center text-xs">${score_neutro_est ?? ''}</td>
-                    <td class="px-6 py-4 text-center text-xs">${deneutrosophy_est ?? ''}</td>
                 `;
 
                 tbody.appendChild(fila);

--- a/intelligent_systems/analisis_eficiencia/views.py
+++ b/intelligent_systems/analisis_eficiencia/views.py
@@ -52,7 +52,7 @@ def obtener_resultados_encuesta_estudiantes(request):
     for item in top_ast:
         item['algoritmo'] = 'Árbol de Sintaxis Abstracta'
     for item in top_fl:
-        item['algoritmo'] = 'Lógica Difusa'
+        item['algoritmo'] = 'Lógica Neutrosófica'
 
 
     return JsonResponse({
@@ -88,7 +88,7 @@ def obtener_resultados_encuesta_profesores(request):
     for item in top_ast:
         item['algoritmo'] = 'Árbol de Sintaxis Abstracta'
     for item in top_fl:
-        item['algoritmo'] = 'Lógica Difusa'
+        item['algoritmo'] = 'Lógica Neutrosófica'
 
 
     return JsonResponse({

--- a/intelligent_systems/migration_excel/templates/migration_excel.html
+++ b/intelligent_systems/migration_excel/templates/migration_excel.html
@@ -6,10 +6,10 @@
   <div class="grid grid-cols-1 md:grid-cols-3 mb-8">
     <div class="col-span-2">
       <h1 class="text-3xl font-bold text-blue-700 mb-2">
-        Subir Archivo de Excel para los algoritmos de AST y LD
+        Subir Archivo de Excel para los algoritmos de AST y LN
       </h1>
       <h2 class="text-xl font-medium text-blue-500">
-        (Arbol de Sintaxis Abstracta y Lógica Difusa (LD))
+        (Arbol de Sintaxis Abstracta y Lógica Neutrosófica (LN))
       </h2>
     </div>
     <div class="flex justify-end items-start">


### PR DESCRIPTION
## Summary
- Renamed front-end labels from Fuzzy Logic (LD/FL) to Neutrosophic Logic (LN)
- Simplified assigned teachers table by hiding neutrosophic score and student columns
- Reduced neutrosophic analysis page to only include explanatory section

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ac3a82a508328a0da1ea3190d835b